### PR TITLE
bug-fix: createExperiences fails w/ empty userId list

### DIFF
--- a/server/src/utils/testDataGen.ts
+++ b/server/src/utils/testDataGen.ts
@@ -252,7 +252,7 @@ export const createExperiences = (n: number, userIds: ObjectId[] = []) => {
       flavourProfile: flavourProfiles[randomInt(flavourProfiles.length)],
       periodOfLifeAssociation: periodOfLifeAssociations[randomInt(periodOfLifeAssociations.length)],
       placesToGetFood: createRandomPlaces(randomInt(3)),
-      creatorId: Math.random() < 0.4 ? undefined : userIds[randomInt(userIds.length)]
+      creatorId: userIds.length ? userIds[randomInt(userIds.length)] : undefined
     } as Experience);
   }
 


### PR DESCRIPTION
Handled case where userId list is empty in createExperiences function